### PR TITLE
Added jsnext:main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.3",
   "description": "Async route component for preact-router",
   "main": "dist/index.js",
+  "jsnext:main": "src/index.js",
   "scripts": {
     "clean": "rm -rf dist/*",
     "build": "npm-run-all clean transpile",


### PR DESCRIPTION
Added jsnext:main to your package.json to match the preact and preact-router packages.  Rollup (using rollup-plugin-node-resolve) is able to bundle it that way without having to resort to using another plugin.