### PR TITLE
Passing props as 3rd argument to getComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ check README :point_down:
   import Loading from './Components/Loading/Loading.jsx';
   /** @jsx h */
 
-  function getProfile(){
+  /**
+    arguments passed to getComponent:
+      url -- matched url
+      cb  -- in case you are not returning a promise
+      props -- props that component will recive upon being loaded
+  */
+  function getProfile(url, cb, props){
   	return System.import('../component/Profile/Profile.jsx').then(module => module.default);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ class AsyncRoute extends Component {
 					componentData: component
 				});
 			}
-		});
+		}, Object.assign({}, this.props, this.props.matches));
 
 		// In case returned value was a promise
 		if (componentData && componentData.then) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -131,4 +131,22 @@ describe('Async Route', () => {
 			done();
 		},400);
 	});
+
+	it('should pass matches to getComponent', () => {
+		let containerTag = document.createElement('div');
+		let controlMatch = Math.random().toString();
+		let controlProp = Math.random();
+		let recivedMatch;
+		let recivedProp;
+
+		let getComponent = function(url, cb, props) {
+			recivedMatch = props.pid;
+			recivedProp = props.sequence;
+			cb({component: props => null});
+		};
+		render(<Router><AsyncRoute path='/profile/:pid' sequence={controlProp} getComponent={getComponent} /></Router>, containerTag);
+		route('/profile/' + controlMatch);
+		expect(recivedMatch).equal(controlMatch);
+		expect(recivedProp).equal(recivedProp);
+	})
 });


### PR DESCRIPTION
This is very useful for prefetching, as it gives developers ability to predict what data route will need and fetch it alongside with component, which is faster then waterfall fetching
----------
Implemented
Clarified that in readme
Added a test for that
Checked that Object.assign is being repaced with a polyfill
Checked that these are the same props actual component will recive upon being loaded