### PR TITLE
Bug/Fixed typescript path prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preact-async-route",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Async route component for preact-router",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,7 @@
 import { Component, FunctionalComponent } from 'preact';
 
 interface IAsyncRouteProps {
+    path: string;
     component?: any;
     getComponent?: (
         this: AsyncRoute,


### PR DESCRIPTION
Added missing `path` property to TypeScript interface.

- Added `path` to `IAsyncRouteProps`