### PR TITLE
Mark path prop as optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 import { Component, FunctionalComponent } from 'preact';
 
 interface IAsyncRouteProps {
-    path: string;
+    path?: string;
     component?: any;
     getComponent?: (
         this: AsyncRoute,


### PR DESCRIPTION
The `path` prop on the `AsyncRoute` component is not required like the TypeScript types currently reflect. This PR simply marks it as optional.

I bumped into this issue when I was trying to use an `AsyncRoute` as the default route like mentioned in the [preact-router docs](https://github.com/preactjs/preact-router#handling-urls):
```tsx
<Router>
  <A path="/" />
  <B path="/b" id="42" />
  <C path="/c/:id" />
  <C path="/d/:optional?/:params?" />
  <D path="/e/:remaining_path*" />
  <E path="/f/:remaining_path+" />
  <F default />   <-- There is no path attribute on this component
</Router>
```

Thanks!